### PR TITLE
22.07.08 (yeonju)

### DIFF
--- a/BOJ/01931-회의실_배정/01931-회의실_배정-yeonju.py
+++ b/BOJ/01931-회의실_배정/01931-회의실_배정-yeonju.py
@@ -1,1 +1,17 @@
-# git commit -m "submit : BOJ 01931 회의실 배정 (yeonju)"
+n = int(input())
+li = []
+for i in range(n):
+    start, end = map(int, input().split())
+    li.append((start, end))
+
+ordered = sorted(li, key=lambda x: (x[1], x[0]))
+
+cnt = 0
+end_time = 0
+
+for s, e in ordered:
+    if s >= end_time:
+        cnt += 1
+        end_time = e
+
+print(cnt)

--- a/BOJ/02606-바이러스/02606-바이러스-yeonju.py
+++ b/BOJ/02606-바이러스/02606-바이러스-yeonju.py
@@ -1,1 +1,32 @@
-# git commit -m "submit : BOJ 02606 바이러스 (yeonju)"
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+
+def bfs(start):
+    queue = deque()
+    queue.append(start)
+
+    while queue:
+        cur_node = queue.popleft()
+
+        for next_node in graph[cur_node]:
+            if not visited[next_node]:
+                queue.append(next_node)
+                visited[next_node] = 1
+    return
+
+
+n = int(input())
+m = int(input())
+
+graph = [[] for _ in range(n + 1)]
+visited = [0 for i in range(n + 1)]
+
+for i in range(m):
+    a, b = map(int, input().split())
+    graph[a].append(b)
+    graph[b].append(a)
+
+bfs(1)
+print(sum(visited) - 1)

--- a/BOJ/02630-색종이_만들기/02630-색종이_만들기-yeonju.py
+++ b/BOJ/02630-색종이_만들기/02630-색종이_만들기-yeonju.py
@@ -1,1 +1,28 @@
-# git commit -m "submit : BOJ 02630 색종이 만들기 (yeonju)"
+def dfs(x, y, n):
+    global white, blue
+    color_check = arr[x][y]
+
+    for i in range(x, x + n):
+        for j in range(y, y + n):
+            if arr[i][j] != color_check:
+                for k in range(2):
+                    for l in range(2):
+                        dfs(x + k * (n // 2), y + l * (n // 2), n // 2)
+                return
+
+    if color_check == 0:
+        white += 1
+    else:
+        blue += 1
+
+
+n = int(input())
+arr = [list(map(int, input().split())) for _ in range(n)]
+
+white = 0
+blue = 0
+
+dfs(0, 0, n)
+
+print(white)
+print(blue)

--- a/BOJ/07576-토마토/07576-토마토-yeonju.py
+++ b/BOJ/07576-토마토/07576-토마토-yeonju.py
@@ -1,1 +1,42 @@
-# git commit -m "submit : BOJ 07576 토마토 (yeonju)"
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+
+def bfs():
+    while queue:
+        x, y = queue.popleft()
+
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+
+            if 0 <= nx < n and 0 <= ny < m:
+                if arr[nx][ny] == 0:
+                    arr[nx][ny] = arr[x][y] + 1
+                    queue.append((nx, ny))
+
+
+m, n = map(int, input().split())
+arr = [list(map(int, input().split())) for _ in range(n)]
+res = 0
+queue = deque()
+
+for i in range(n):
+    for j in range(m):
+        if arr[i][j] == 1:
+            queue.append((i, j))
+
+bfs()
+
+for row in arr:
+    for i in row:
+        if i == 0:
+            print(-1)
+            exit(0)
+    res = max(res, max(row))
+
+print(res - 1)

--- a/BOJ/07662-이중_우선순위_큐/07662-이중_우선순위_큐-yeonju.py
+++ b/BOJ/07662-이중_우선순위_큐/07662-이중_우선순위_큐-yeonju.py
@@ -1,1 +1,48 @@
-# git commit -m "submit : BOJ 07662 이중 우선순위 큐 (yeonju)"
+import sys
+import heapq
+from collections import defaultdict
+input = sys.stdin.readline
+
+t = int(input())
+
+for tc in range(t):
+    min_h = []
+    max_h = []
+    dic = defaultdict(int)
+
+    k = int(input())
+
+    for _ in range(k):
+        operation, num = map(str, input().split())
+
+        if operation == 'I':
+            heapq.heappush(min_h, int(num))
+            heapq.heappush(max_h, -int(num))
+            dic[int(num)] += 1
+
+        else:
+            if num == '-1':
+                while min_h:
+                    temp = heapq.heappop(min_h)
+
+                    if dic[temp] > 0:
+                        dic[temp] -= 1
+                        break
+
+            elif num == '1':
+                while max_h:
+                    temp = -heapq.heappop(max_h)
+
+                    if dic[temp] > 0:
+                        dic[temp] -= 1
+                        break
+
+    li = []
+    for i in dic:
+        if dic[i] > 0:
+            li.append(i)
+
+    if li:
+        print(max(li), min(li))
+    else:
+        print('EMPTY')

--- a/BOJ/09095-1,_2,_3_더하기/09095-1,_2,_3_더하기-yeonju.py
+++ b/BOJ/09095-1,_2,_3_더하기/09095-1,_2,_3_더하기-yeonju.py
@@ -1,1 +1,15 @@
-# git commit -m "submit : BOJ 09095 1, 2, 3 더하기 (yeonju)"
+import sys
+input = sys.stdin.readline
+
+dp = [0 for _ in range(11)]
+dp[1] = 1
+dp[2] = 2
+dp[3] = 4
+
+for i in range(4, 11):
+    dp[i] = dp[i - 3] + dp[i - 2] + dp[i - 1]
+
+t = int(input())
+for tc in range(t):
+    n = int(input())
+    print(dp[n])

--- a/BOJ/11279-최대_힙/11279-최대_힙-yeonju.py
+++ b/BOJ/11279-최대_힙/11279-최대_힙-yeonju.py
@@ -1,1 +1,13 @@
-# git commit -m "submit : BOJ 11279 최대 힙 (yeonju)"
+import sys
+import heapq
+input = sys.stdin.readline
+
+n = int(input())
+h = []
+
+for _ in range(n):
+    x = int(input())
+    if x:
+        heapq.heappush(h, -x)
+    else:
+        print(-heapq.heappop(h) if h else 0)


### PR DESCRIPTION
## 💡 Idea & Algorithm <!-- 핵심 아이디어 및 알고리즘 -->

### 회의실 배정:
* 빨리 끝날수록 더 많은 회의를 할 수 있기에 우선 끝나는 시간을 기준으로 오름차순 정렬합니다.
* 끝나는 시간은 같고, 시작 시간이 다른 경우 (1, 2) (2, 2) 순으로 배치해야 더 많은 회의를 할 수 있습니다. 그렇기에 이런 경우, 시작 시간을 기준으로 오름차순 정렬을 해줍니다. 

<br />

### 바이러스:
* bfs 로 인접한 노드들을 방문하며 queue 가 다 비었을 때 방문한 노드(= 감염된 컴퓨터들)의 개수를 세줍니다.

<br />

### 이중 우선순위 큐:
* 우선 순위 큐 하나로 어케 안될까 했지만.... 역시 두 개를 써야하는 문제
* defaultdict 에 해당 데이터의 개수를 카운트 해줬습니다. 만약에 해당 데이터의 개수가 1보다 적다면 heaq 에 이제 더는 없는 원소라고 생각해줬습니다.

<br />

### 색종이 만들기:
* '종이의 개수'랑 똑같은 분할 정복 문제
* 종이의 개수가 9 등분이었다면 이 문제는 4등분이어서 3을 2로 바꿔주기만 하면 됩니다.

<br />

### 토마토:
* 여러 군데에서 토마토가 동시에 익습니다. 그렇기에 토마토가 있는 한 곳에서 bfs 로 탐색을 다 마친 후, 다른 토마토로 접근하면 안 됩니다.
* 다시 말해, bfs 돌기 전에 토마토가 있는 위치를 싹 다 queue에 우선적으로  담아야 합니다. 그 후 bfs 로 탐색을 시켜줍니다.

<br />

### 1, 2, 3 만들기:
* dp 문제 
* 1 * 1 , 2 * 2, 3 * 3 크기를 만들 수 있는 경우의 수를 dp 에 미리 저장시켜놓습니다.
* 그 다음 4번째부터는 1, 2, 3 에서 만들 수 있는 각각의 경우의 수만큼을 다 더해주면 됩니다.
* 1 칸에서 3개짜리 1개 추가, 2칸에서 2개짜리 2개 추가, 3칸에서는 1개짜리 4개추가 이렇게 반복하다보면 해당 숫자의 모든 경우의 수가 나옵니다.
* 참고로, dp 를 각각의 test case 안에다가 선언했더니 런타임에러(IndexError) 가 나던군요. 어짜피 10까지만 궁금하다고 문제에서 주어졌으니, 그냥 맨 위로 뺐습니다.

<br />

### 최대 힙:
* 우선순위 큐의 최소 힙을 변형한 문제
* 1 ,2, 3 으로 정렬되어 있으면 각각의 원소에 - 를 붙여서 - 3, -2, -1 순으로 만들어줍니다. 그 다음 맨 앞에 있는 최솟값을 꺼낸 후 -만 붙여주면 원하는 해답을 구할 수 있습니다.
* sys.stdin.readline 안 붙이면 시간 초과 나네요... 습관적으로 sys.stdin.readline 을 붙혀와서 어떤 경우에 시간 초과가 나고 어떤 경우에는 안 나는지 다소 명확히 알지는 못했는데, 그게 슬슬 궁금해집니다 ! 조만간 공부를 해봐야겠어요 .. ! 

## 💬 Comment <!-- 후기 -->
